### PR TITLE
Gui enhancment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # L2 network switch simulation
 
-- By: BEng. Grzegorz Jaskuła
-- Supervision: Prof. Maciej Stasiak
+- By: BEng. Grzegorz Jaskuła, BEng/ Adam Rektor
+- Supervision: Prof. Maciej Stasiak, Phd. Slawomir Hanczewski
 
 Poznań University of Technology, 2023
 
@@ -17,11 +17,12 @@ This program is simulating layer 2 network switch with 8 ethernet interfaces. Ea
 
 - Traffic generated between 2-8 interfaces
 - Fixed and varied frames length
-- Store and forward switching mode, cut through in progress
+- Store and forward and cut through switching modes
 - Adjustable frame handling time
 - Adjustable minimal time between frames
 - Statistics display including: number of frames received/transmitted/lost, lost percentage, data transfer in/out, CAM (MAC) table view, interface buffer view
 - Image of switch with flashing LEDs
+- More features will be added in the future
 
 Simulator is run for time specified in seconds. **Time given refers to REAL COMPUTING TIME, not switch running time**. It means running speed may differ depending on hardware. Simulation can be resumed in the same way. Button *HALT* is supposed to stop simulator in emergency - use with caution as it violently kills the thread.
 

--- a/src/RNG/Uniform.java
+++ b/src/RNG/Uniform.java
@@ -9,8 +9,8 @@ public class Uniform extends Random{
 	{
 		return Math.random();
 	}
-	public int getNextInt(int min, int max)
+	public int getNextInt(int Min, int Max)
 	{
-	    return (int) ((Math.random() * (max - min)) + min);
+		return Min + (int)(Math.random() * ((Max - Min) + 1));
 	}
 }

--- a/src/buffer/Buffer.java
+++ b/src/buffer/Buffer.java
@@ -54,6 +54,7 @@ public class Buffer {
 	public void clear()
 	{
 		for(int i = 0; i < currentSize; i++) this.pop();
+		this.currentSize = 0;
 	}
 	
 	public String getString()

--- a/src/l2/MACTable.java
+++ b/src/l2/MACTable.java
@@ -93,4 +93,8 @@ public class MACTable {
 		this.interf.clear();
 		this.validFor.clear();
 	}
+	public void setDefaultValidity(Integer newVal)
+	{
+		this.defaultValidity = newVal;
+	}
 }

--- a/src/l2/Simulator.java
+++ b/src/l2/Simulator.java
@@ -62,7 +62,7 @@ public class Simulator extends JFrame implements ActionListener {
 	String[] rngTypeString = {"Uniform", "Exponential", "Normal"};
 	JComboBox<String> rngType = new JComboBox<String>(rngTypeString);
 	JLabel rngTypeTxt = new JLabel();
-	String[] handlingString = {"Instant", "10% of frame length", "25% of frame length", "50% of frame length" , "100% of frame length" , "Exponential"};
+	String[] handlingString = {"Instant", "10% of frame length", "25% of frame length", "50% of frame length" , "100% of frame length" , "Exp(0.001)"};
 	JTextField rngParam1 = new JTextField();
 	JTextField rngParam2 = new JTextField();
 	JLabel rngParamsTxt = new JLabel();
@@ -252,11 +252,11 @@ public class Simulator extends JFrame implements ActionListener {
 		frameLength.add(frameLengthVary);
 		frameLengthTxt.setBounds(950, 400, 140, 20);
 		frameLengthTxt.setText("Frame length");
-		frameLengthFixed.setBounds(950, 430, 200, 20);
+		frameLengthFixed.setBounds(950, 430, 150, 20);
 		frameLengthFixed.setText("Fixed 64B");
 		frameLengthFixed.setSelected(true);
 		frameLengthFixed.addActionListener(this);
-		frameLengthVary.setBounds(950, 450, 200, 20);;
+		frameLengthVary.setBounds(950, 450, 150, 20);;
 		frameLengthVary.setText("64B - 1536B");
 		frameLengthVary.addActionListener(this);
 		
@@ -473,7 +473,7 @@ public class Simulator extends JFrame implements ActionListener {
 					while(byteCounter < 5120)
 					{
 						//Push new frame if ready, Tx is free and Rx not empty
-						if(mySwitch.ethernet[i].Tx.IdleSwitch <= 0
+						if(mySwitch.ethernet[i].Tx.IdleSwitch <= 0 //Edit this line to make it store&forward - add checking if Rx buffer is 0 while s&f, no check in cut-through
 								&& !mySwitch.ethernet[i].Rx.isEmpty()
 								&& mySwitch.ethernet[i].Tx.getCurrentSize() < mySwitch.ethernet[i].Tx.getSize())
 						{

--- a/src/l2/Simulator.java
+++ b/src/l2/Simulator.java
@@ -407,10 +407,11 @@ public class Simulator extends JFrame implements ActionListener {
 				if (ChronoUnit.SECONDS.between(then, LocalDateTime.now()) >= time) break;
 				progressBar.setValue((int) ChronoUnit.SECONDS.between(then, LocalDateTime.now()));
 				//ACTUAL SWITCH
-				for(Integer i = 0; i < PORTNUMBER; i++) //RX
+				for(Integer i = 0; i < PORTNUMBER; i++)
 				{
 					if(mySwitch.ethernet[i].isDown()) continue;
 					Integer byteCounter = 0; //How many bytes interface has received
+					//RECEIVING
 					while(byteCounter < 5120)
 					{
 						/*mySwitch.ethernet[2].Rx.push(new traffic.Frame(69, 2, 1, 3, 7));
@@ -465,11 +466,8 @@ public class Simulator extends JFrame implements ActionListener {
 						if(mySwitch.ethernet[i].Rx.isEmpty()) picPort[i].setIcon(portON);
 						else picPort[i].setIcon(portTRX);
 					}
-				}
-				for(Integer i = 0; i < PORTNUMBER; i++) //SWITCHING
-				{
-					if(mySwitch.ethernet[i].isDown()) continue;
-					Integer byteCounter = 0; //How many bytes interface has switched
+					//SWITCHING
+					byteCounter = 0;
 					while(byteCounter < 5120)
 					{
 						//Push new frame if ready, Tx is free and Rx not empty
@@ -518,11 +516,8 @@ public class Simulator extends JFrame implements ActionListener {
 						mySwitch.ethernet[i].Tx.IdleSwitch--;
 						byteCounter++;
 					}
-				}
-				for(Integer i = 0; i < PORTNUMBER; i++) //TX
-				{
-					if(mySwitch.ethernet[i].isDown()) continue;
-					Integer byteCounter = 0; //How many bytes interface has transmitted
+					//TRANSMITTING
+					byteCounter = 0;
 					while(byteCounter < 5120)
 					{
 						if(mySwitch.ethernet[i].Tx.Idle <= 0
@@ -757,6 +752,7 @@ public class Simulator extends JFrame implements ActionListener {
 		buttonStop.setEnabled(false);
 		buttonClr.setEnabled(true);
 		buttonFlushCAM.setEnabled(true);
+		buttonClearBuffers.setEnabled(true);
 		for(Integer i = 0; i < PORTNUMBER; i++) ethernet[i].setEnabled(true);
 		frameMinDelay.setEnabled(true);
 		rngType.setEnabled(true);
@@ -776,6 +772,7 @@ public class Simulator extends JFrame implements ActionListener {
 		buttonStop.setEnabled(true);
 		buttonClr.setEnabled(false);
 		buttonFlushCAM.setEnabled(false);
+		buttonClearBuffers.setEnabled(false);
 		for(Integer i = 0; i < PORTNUMBER; i++) ethernet[i].setEnabled(false);
 		frameMinDelay.setEnabled(false);
 		rngType.setEnabled(false);

--- a/src/l2/Simulator.java
+++ b/src/l2/Simulator.java
@@ -147,7 +147,7 @@ public class Simulator extends JFrame implements ActionListener {
 		status.setFont(new Font("Serif", Font.PLAIN, 24));;
 		copy.setBounds(5, 740, 1180, 30);
 		copy.setFont(new Font("Serif", Font.PLAIN, 10));
-		copy.setText("©Grzegorz Jaskuła 2023, supervised by prof. Maciej Stasiak, Poznan University of Technology. This software is for educational purposes only and is provided as it is.");
+		copy.setText("©Grzegorz Jaskuła, Adam Rektor 2023. Supervised by prof. Maciej Stasiak, Phd. Slawomir Hanczewski. Poznan University of Technology. This software is for educational purposes only and is provided as it is.");
 		
 		iterationsTxt.setBounds(1050, 30, 140, 30);
 		iterationsTxt.setText("Run for seconds");

--- a/src/l2/Simulator.java
+++ b/src/l2/Simulator.java
@@ -402,7 +402,7 @@ public class Simulator extends JFrame implements ActionListener {
 							Boolean broadcast = false;
 							int targetHost = -1;
 							if(broadcastRNG.getNextInt(0, 99) < broadcastTreshold) broadcast = true;
-							while(!targetHostUp)
+							else while(!targetHostUp)
 							{
 								targetHost = (targetPortRNG.getNextInt(0, 7));
 								if(mySwitch.ethernet[targetHost].isUp() && targetHost != i) targetHostUp = true;

--- a/src/l2/Simulator.java
+++ b/src/l2/Simulator.java
@@ -730,6 +730,7 @@ public class Simulator extends JFrame implements ActionListener {
 		frameLengthVary.setEnabled(true);
 		handling.setEnabled(true);
 		broadcast.setEnabled(true);
+		MAC_TTL.setEnabled(true);
 	}
 	
 	public void disableGUI() //Before simulation
@@ -746,6 +747,7 @@ public class Simulator extends JFrame implements ActionListener {
 		frameLengthVary.setEnabled(false);
 		handling.setEnabled(false);
 		broadcast.setEnabled(false);
+		MAC_TTL.setEnabled(false);
 	}
 	
 	public void setStatus(String msg, Boolean isError)


### PR DESCRIPTION
-Added RNG parameters to GUI. Uniform, exponential and normal are support atm.
-Added broadcast traffic treshold to GUI (broadcast while learning MACs will still apply beside this setting)
-Added CAM table entry time to live (TTL) parameter to GUI
-Exponential in frame handle time renamed to Exp(0.001)

Switching mode is still under development due to nulls being returned while using varied frame length. Abandoning this feature may be considered eventually.

Uniform and normal RNGs stucking the simulator with only 2 interfaces active is known and addressed.